### PR TITLE
changed google maps api key usage from env to conf

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -16,13 +16,18 @@ class FieldServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-//		$this->publishes([
-//            $this->configPath() => config_path('nova-address-field.php'),
-//        ], 'nova-address-field-config');
+        /**
+         * Required this script to publish the nova-address-field.php file
+         * so user can set the key from nova-address-field.php,
+         * Sometimes cache create issue to get the key from env('GOOGLE_PLACES_API_KEY').
+         */
+		$this->publishes([
+           $this->configPath() => config_path('nova-address-field.php'),
+       ], 'nova-address-field-config');
 		
         Nova::serving(function (ServingNova $event) {
-//            $key = Config::get('nova-address-field.api_key');
-            $key = env('GOOGLE_PLACES_API_KEY');
+            $key = Config::get('nova-address-field.api_key');
+            // $key = env('GOOGLE_PLACES_API_KEY');
             Nova::script('google-maps', "https://maps.googleapis.com/maps/api/js?key={$key}&libraries=places");
             Nova::script('address-field', __DIR__.'/../dist/js/field.js');
             Nova::style('address-field', __DIR__.'/../dist/css/field.css');


### PR DESCRIPTION
sometimes cache the config it won't pickup the api key and we can't use the plugin properly due to key issue.  So I uncommitted the code which will publish the config file for users and use the key from config file instead of env